### PR TITLE
update to work with laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,16 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "filament/filament": "^3.0",
-        "illuminate/contracts": "^10.0|^11.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0",
         "ringlesoft/laravel-process-approval": "^1.0",
         "spatie/laravel-package-tools": "^1.15.0",
         "spatie/laravel-permission": "^6.1"
     },
     "require-dev": {
-        "nunomaduro/collision": "^7.9",
-        "orchestra/testbench": "^8.0",
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^9.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0"


### PR DESCRIPTION
@eighty9nine 
I just have been updated to work seamlessly with Laravel 12. Previously, it was only compatible with Laravel 11 and below. This fix involved updating PHP and other package dependencies in composer.json.